### PR TITLE
Only count the number of entries in each section

### DIFF
--- a/sitemap/templates/_settings.html
+++ b/sitemap/templates/_settings.html
@@ -54,7 +54,7 @@
           {%- endif -%}
         </td>
         <td>
-          {{- craft.entries.section(section).limit(null)|length -}}
+          {{- craft.entries.section(section).total() -}}
         </td>
         <td>
           {{- forms.selectField({


### PR DESCRIPTION
The original code was retrieving all the entries from the database every time you visited the settings page, which made for a very slow page-load and/or out-of-memory errors on sites with a lot of entries. I switched it to use `total()` (which maps to a SQL `COUNT()` query), which is much faster.
