### PR TITLE
Multi-locale domain support, fixes #17

### DIFF
--- a/sitemap/services/SitemapService.php
+++ b/sitemap/services/SitemapService.php
@@ -107,12 +107,31 @@ class SitemapService extends BaseApplicationComponent
      */
     public function addElement(BaseElementModel $element, $changefreq = null, $priority = null)
     {
-        $url = $this->addUrl($element->url, $element->dateUpdated, $changefreq, $priority);
-
         $locales = craft()->elements->getEnabledLocalesForElement($element->id);
+        $locale_urls = array();
         foreach ($locales as $locale) {
-            $href = craft()->sitemap->getElementUrlForLocale($element, $locale);
-            $url->addAlternateUrl($locale, $href);
+            $locale_urls[$locale] = craft()->sitemap->getElementUrlForLocale($element, $locale);
+        }
+
+        if(defined('CRAFT_LOCALE')) {
+            // Render sitemap for one specific locale only (single locale domain), e.g. example.de/sitemap.xml
+            
+            $url = $this->addUrl($element->url, $element->dateUpdated, $changefreq, $priority);
+
+            foreach ($locale_urls as $locale => $locale_url) {
+                $url->addAlternateUrl($locale, $locale_url);
+            }
+        }
+        else {
+            // Render sitemap for all locales (multi-locale domain), e.g. example.com/sitemap.xml
+
+            foreach ($locale_urls as $locale => $locale_url) {
+                $url = $this->addUrl($locale_url, $element->dateUpdated, $changefreq, $priority);
+                
+                foreach ($locale_urls as $locale => $locale_url) {
+                    $url->addAlternateUrl($locale, $locale_url);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I have found some time to dig into this :)

This PR fixes sitemaps for craft sites, that have one shared `sitemap.xml` for multiple locales, i.e. when multiple locales share the same domain. Previously the sitemap would lack `<url>` tags, as described in #17.

Checking if `CRAFT_LOCALE` is defined makes sure that single-locale domains are not affected by this change.
