### PR TITLE
[bugfix] removed limit on entries fetched with EntryModel

### DIFF
--- a/sitemap/services/SitemapService.php
+++ b/sitemap/services/SitemapService.php
@@ -127,7 +127,7 @@ class SitemapService extends BaseApplicationComponent
     {
         $criteria = craft()->elements->getCriteria(ElementType::Entry);
         $criteria->section = $section;
-        foreach ($criteria->find() as $element) {
+        foreach ($criteria->find(['limit' => -1]) as $element) {
             $this->addElement($element, $changefreq, $priority);
         }
     }
@@ -144,7 +144,7 @@ class SitemapService extends BaseApplicationComponent
         $criteria = craft()->elements->getCriteria(ElementType::Category);
         $criteria->group = $categoryGroup;
 
-        $categories = $criteria->find();
+        $categories = $criteria->find(['limit' => -1]);
         foreach ($categories as $category) {
             $this->addElement($category, $changefreq, $priority);
         }


### PR DESCRIPTION
Fixed a bug where the maximum amount of entries fetched was smaller than the amount of entries in the database. This due to the fact that craft only fetches 100 records by default.
