### PR TITLE
Update In service so that it can support Protocol-relative URL format

### DIFF
--- a/sitemap/services/SitemapService.php
+++ b/sitemap/services/SitemapService.php
@@ -107,7 +107,7 @@ class SitemapService extends BaseApplicationComponent
      */
     public function addElement(BaseElementModel $element, $changefreq = null, $priority = null)
     {
-        $url = $this->addUrl($element->url, $element->dateUpdated, $changefreq, $priority);
+        $url = $this->addUrl(ltrim($element->url, '//'), $element->dateUpdated, $changefreq, $priority);
 
         $locales = craft()->elements->getEnabledLocalesForElement($element->id);
         foreach ($locales as $locale) {
@@ -166,7 +166,7 @@ class SitemapService extends BaseApplicationComponent
         $oldUri = $element->uri;
         $element->locale = $locale;
         $element->uri = craft()->elements->getElementUriForLocale($element->id, $locale);
-        $url = $element->getUrl();
+        $url = ltrim($element->getUrl(), "//");
         $element->locale = $oldLocale;
         $element->uri = $oldUri;
 


### PR DESCRIPTION
I discovered on one of our live sites that when a Protocol-relative URL is used inside the craft config siteUrl property this plugin will fail. This small update will prevent it. kind regards, Roland